### PR TITLE
use the not-simple AnnotationReader

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -9,6 +9,8 @@ require_once "vendor/autoload.php";
 // Create a simple "default" Doctrine ORM configuration for Annotations
 $isDevMode = true;
 $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/src"), $isDevMode);
+// or force Doctrine to use the notsimple AnnotationReader ( simple annotation driver doesn't recognise the @ORM\Entity annotation )
+// $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/src"), $isDevMode, null, null, false);
 // or if you prefer yaml or XML
 //$config = Setup::createXMLMetadataConfiguration(array(__DIR__."/config/xml"), $isDevMode);
 //$config = Setup::createYAMLMetadataConfiguration(array(__DIR__."/config/yaml"), $isDevMode);


### PR DESCRIPTION
set useSimpleAnnotationReader param to false, force Doctrine to use the not-simple AnnotationReader, simple annotation driver doesn't recognise the @ORM\* annotations